### PR TITLE
kirkstone branch build support

### DIFF
--- a/.github/workflows/kas-build-oe4t.yml
+++ b/.github/workflows/kas-build-oe4t.yml
@@ -15,14 +15,17 @@ env:
 jobs:
   build:
     runs-on: self-hosted
-
+    strategy:
+      matrix:
+        buildproj: [ swupdate-oe4t, swupdate-rootfs-overlay-oe4t ]
+        branch: [ kirkstone, master ]
     steps:
       - uses: actions/checkout@v4
 
       - name: Set env vars
         run: |
           if [ -n "${SSTATE_DIR}" ]; then
-            export SSTATE_DIR=${SSTATE_DIR}/swupdate-oe4t-master
+            export SSTATE_DIR=${SSTATE_DIR}/swupdate-oe4t-${{ matrix.branch }}
             echo "SSTATE_DIR=${SSTATE_DIR}" >> "$GITHUB_ENV"
           fi
           echo "Running kas build with SSTATE_DIR=${SSTATE_DIR} DL_DIR=${DL_DIR}"
@@ -32,43 +35,23 @@ jobs:
           fi
           echo "Using ARTIFACT_RETENTION_DAYS=${ARTIFACT_RETENTION_DAYS}"
  
-      - name: Build kas swupdate demo
+      - name: Build ${{ matrix.buildproj }} branch ${{ matrix.branch }}
         run: |
-          export buildproj=swupdate-oe4t
-          echo "buildproj=${buildproj}" >> "$GITHUB_ENV"
-          echo "Making build directory ${buildproj}"
-          mkdir ${buildproj}
-          echo "Changing to build directory ${buildproj}"
-          cd ${buildproj}
-          echo "running kas container build for ${buildproj}"
-          kas-container build ../kas/${buildproj}.yml
+          export builddir=${{ matrix.buildproj }}-${{ matrix.branch }}
+          echo "builddir=${builddir}" >> "$GITHUB_ENV"
+          echo "Making build directory ${builddir}"
+          mkdir ${builddir}
+          echo "Changing to build directory ${builddir}"
+          cd ${builddir}
+          echo "running kas container build for ${{ matrix.buildproj }} on branch ${{ matrix.branch }}"
+          kas-container build ../kas/${{ matrix.buildproj}}.yml:../kas/include/${{ matrix.branch }}.yml
 
-      - name: Upload artifacts
+      - name: Upload artifacts for ${{ matrix.buildproj }} branch ${{ matrix.branch }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.buildproj }}
+          name: ${{ matrix.buildproj }}-${{ matrix.branch }}
           path: |
-           ${{ env.buildproj}}/build/tmp/deploy/images/*/*.tegraflash.tar.zst
-           ${{ env.buildproj}}/build/tmp/deploy/images/*/*.swu
+           ${{ env.builddir }}/build/tmp/deploy/images/*/*.tegraflash.tar.*
+           ${{ env.builddir }}/build/tmp/deploy/images/*/*.swu
            retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-        
-      - name: Build kas swupdate rootfs overlay demo
-        run: |
-          if [ -n "${SSTATE_DIR}" ]; then
-            export SSTATE_DIR=${SSTATE_DIR}/swupdate-oe4t-master
-          fi
-          echo "Running kas build with SSTATE_DIR=${SSTATE_DIR} DL_DIR=${DL_DIR}"
-          export buildproj=swupdate-rootfs-overlay-oe4t
-          echo "buildproj=${buildproj}" >> "$GITHUB_ENV"
-          mkdir ${buildproj}
-          cd ${buildproj}
-          kas-container build ../kas/${buildproj}.yml
 
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ env.buildproj }}
-          path: |
-           ${{ env.buildproj }}/build/tmp/deploy/images/*/*.tegraflash.tar.zst
-           ${{ env.buildproj }}/build/tmp/deploy/images/*/*.swu
-           retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}

--- a/README.md
+++ b/README.md
@@ -21,6 +21,18 @@ where `${project}` is a specific kas configuration to demo
 from the list of .yml files in the [kas](kas) subdir
 and outlined below
 
+## Building Alternate Branches
+
+The default branch build configuration is for master/main on each project.
+
+To build for alternate branches, use the `kas/include/${branch}` file on
+the config file list as outlined in the [kas build commandline instructions](https://kas.readthedocs.io/en/latest/userguide/project-configuration.html#including-configuration-files-via-the-command-line)
+
+So for example, to build the swupdate-oe4t project for kirkstone branch, use
+```
+kas build --update ../kas/swupdate-oe4t.yml:../kas/include/kirkstone.yml
+```
+
 ## Demo Projects
 
 ### swupdate-oe4t

--- a/kas/include/kirkstone.yml
+++ b/kas/include/kirkstone.yml
@@ -6,10 +6,6 @@ repos:
     url: https://github.com/Trellis-Logic/tegra-demo-distro.git
     branch: kirkstone+swupdate
 
-  meta-tegra:
-    url: https://github.com/Trellis-Logic/meta-tegra.git
-    branch: kirkstone+compat-spec-fix
-
   meta-swupdate:
     url: https://github.com/sbabic/meta-swupdate.git
     branch: kirkstone

--- a/kas/include/kirkstone.yml
+++ b/kas/include/kirkstone.yml
@@ -1,6 +1,28 @@
 header:
   version: 17
 
+repos:
+  tegra-demo-distro:
+    url: https://github.com/Trellis-Logic/tegra-demo-distro.git
+    branch: kirkstone+swupdate
+
+  meta-tegra:
+    url: https://github.com/Trellis-Logic/meta-tegra.git
+    branch: kirkstone+compat-spec-fix
+
+  meta-swupdate:
+    url: https://github.com/sbabic/meta-swupdate.git
+    branch: kirkstone
+
+  kas-demos:
+    layers:
+      layers/meta-trellis-swupdate-rootfs-overlay-oe4t: disabled
+
+  kas-demos-clone:
+    url: https://github.com/Trellis-Logic/kas-demos.git
+    layers:
+      layers/meta-trellis-swupdate-rootfs-overlay-oe4t:
+
 defaults:
   repos:
     branch: kirkstone

--- a/kas/swupdate-rootfs-overlay-oe4t.yml
+++ b/kas/swupdate-rootfs-overlay-oe4t.yml
@@ -15,3 +15,4 @@ local_conf_header:
     IMAGE_FSTYPES += "tegra_dataimg"
     EXTRA_IMAGE_FEATURES = "read-only-rootfs allow-empty-password empty-root-password allow-root-login"
     FILESYSTEM_PERMS_TABLES:remove = "fs-perms-volatile-log.txt"
+    IMAGE_INSTALL:append = " test-rootfs-overlay"

--- a/layers/meta-trellis-swupdate-rootfs-overlay-oe4t/recipes-connectivity/openssh/openssh/10-add-data-ssh-keys-dir.conf
+++ b/layers/meta-trellis-swupdate-rootfs-overlay-oe4t/recipes-connectivity/openssh/openssh/10-add-data-ssh-keys-dir.conf
@@ -1,2 +1,2 @@
 [Service]
-ExecStartPre=mkdir -p /data/ssh/keys
+ExecStartPre=mkdir -p /data/symlinks/etc/ssh/keys

--- a/layers/meta-trellis-swupdate-rootfs-overlay-oe4t/recipes-connectivity/openssh/openssh_%.bbappend
+++ b/layers/meta-trellis-swupdate-rootfs-overlay-oe4t/recipes-connectivity/openssh/openssh_%.bbappend
@@ -4,17 +4,19 @@ SRC_URI:append = " file://10-add-data-ssh-keys-dir.conf \
                    file://10-wait-for-data-overlay-setup.conf \
 "
 
+UNPACKDIR_COMPAT = "${@'${WORKDIR}' if not d.getVar('UNPACKDIR') else d.getVar('UNPACKDIR', expand=True)}"
+
 do_install:append() {
     # target /etc/ssh/keys for readonly mount, we will overlay this dir
     sed -i -r -e 's!HostKey\s+/var/run/ssh!HostKey ${sysconfdir}/ssh/keys!g' ${D}${sysconfdir}/ssh/sshd_config_readonly
     ln -s ../../data/ssh/keys ${D}${sysconfdir}/ssh/keys
-    install -d 0755 ${D}${sysconfdir}/systemd/data-overlay-setup.service.d
-    install ${UNPACKDIR}/10-add-data-ssh-keys-dir.conf -m 0644 ${D}${sysconfdir}/systemd/data-overlay-setup.service.d/
-    install -d 0755 ${D}${sysconfdir}/systemd/sshdgenkeys.service.d
-    install ${UNPACKDIR}/10-wait-for-data-overlay-setup.conf -m 0644 ${D}${sysconfdir}/systemd/sshdgenkeys.service.d/
+    install -d 0755 ${D}${sysconfdir}/systemd/system/data-overlay-setup.service.d
+    install ${UNPACKDIR_COMPAT}/10-add-data-ssh-keys-dir.conf -m 0644 ${D}${sysconfdir}/systemd/system/data-overlay-setup.service.d/
+    install -d 0755 ${D}${sysconfdir}/systemd/system/sshdgenkeys.service.d
+    install ${UNPACKDIR_COMPAT}/10-wait-for-data-overlay-setup.conf -m 0644 ${D}${sysconfdir}/systemd/system/sshdgenkeys.service.d/
 }
 
-FILES:${PN} += "${sysconfdir}/systemd/data-overlay-setup.service.d/*"
-FILES:${PN} += "${sysconfdir}/systemd/sshdgenkeys.service.d/*"
+FILES:${PN} += "${sysconfdir}/systemd/system/data-overlay-setup.service.d/*"
+FILES:${PN} += "${sysconfdir}/systemd/system/sshdgenkeys.service.d/*"
 
 RDEPENDS:${PN} += "data-overlay-setup"

--- a/layers/meta-trellis-swupdate-rootfs-overlay-oe4t/recipes-connectivity/openssh/openssh_%.bbappend
+++ b/layers/meta-trellis-swupdate-rootfs-overlay-oe4t/recipes-connectivity/openssh/openssh_%.bbappend
@@ -9,7 +9,7 @@ UNPACKDIR_COMPAT = "${@'${WORKDIR}' if not d.getVar('UNPACKDIR') else d.getVar('
 do_install:append() {
     # target /etc/ssh/keys for readonly mount, we will overlay this dir
     sed -i -r -e 's!HostKey\s+/var/run/ssh!HostKey ${sysconfdir}/ssh/keys!g' ${D}${sysconfdir}/ssh/sshd_config_readonly
-    ln -s ../../data/ssh/keys ${D}${sysconfdir}/ssh/keys
+    ln -s ../../data/symlinks/etc/ssh/keys ${D}${sysconfdir}/ssh/keys
     install -d 0755 ${D}${sysconfdir}/systemd/system/data-overlay-setup.service.d
     install ${UNPACKDIR_COMPAT}/10-add-data-ssh-keys-dir.conf -m 0644 ${D}${sysconfdir}/systemd/system/data-overlay-setup.service.d/
     install -d 0755 ${D}${sysconfdir}/systemd/system/sshdgenkeys.service.d

--- a/layers/meta-trellis-swupdate-rootfs-overlay-oe4t/recipes-core/base-files/base-files/10-add-data-log-dir.conf
+++ b/layers/meta-trellis-swupdate-rootfs-overlay-oe4t/recipes-core/base-files/base-files/10-add-data-log-dir.conf
@@ -1,2 +1,2 @@
 [Service]
-ExecStartPre=mkdir -p /data/log
+ExecStartPre=mkdir -p /data/symlinks/var/log

--- a/layers/meta-trellis-swupdate-rootfs-overlay-oe4t/recipes-core/base-files/base-files_%.bbappend
+++ b/layers/meta-trellis-swupdate-rootfs-overlay-oe4t/recipes-core/base-files/base-files_%.bbappend
@@ -21,13 +21,13 @@ do_install:append() {
     sed -e"s!@TEGRA_DATA_PART_LABEL@!${TEGRA_DATA_PART_LABEL}!g" -i ${S}/additions.fstab
     cat ${S}/additions.fstab >> ${D}${sysconfdir}/fstab
     ln -s ../data/log ${D}${localstatedir}/log
-    install -d 0755 ${D}${sysconfdir}/systemd/systemd-networkd-persistent-storage.service.d/
-    install -m 0644 10-wait-for-var-volatile-lib.conf ${D}${sysconfdir}/systemd/systemd-networkd-persistent-storage.service.d/
-    install -d 0755 ${D}${sysconfdir}/systemd/systemd-timesyncd.service.d/
-    install -m 0644 10-wait-for-var-volatile-lib.conf ${D}${sysconfdir}/systemd/systemd-timesyncd.service.d/
-    install -d 0755 ${D}${sysconfdir}/systemd/data-overlay-setup.service.d/
+    install -d 0755 ${D}${sysconfdir}/systemd/system/systemd-networkd-persistent-storage.service.d/
+    install -m 0644 10-wait-for-var-volatile-lib.conf ${D}${sysconfdir}/systemd/system/systemd-networkd-persistent-storage.service.d/
+    install -d 0755 ${D}${sysconfdir}/systemd/system/systemd-timesyncd.service.d/
+    install -m 0644 10-wait-for-var-volatile-lib.conf ${D}${sysconfdir}/systemd/system/systemd-timesyncd.service.d/
+    install -d 0755 ${D}${sysconfdir}/systemd/system/data-overlay-setup.service.d/
     # Add the /data/log dir in case it's not there already (upgrade scenario)
-    install -m 0644 10-add-data-log-dir.conf ${D}${sysconfdir}/systemd/data-overlay-setup.service.d/
+    install -m 0644 10-add-data-log-dir.conf ${D}${sysconfdir}/systemd/system/data-overlay-setup.service.d/
 }
 
 RDEPENDS:${PN} += "data-overlay-setup"

--- a/layers/meta-trellis-swupdate-rootfs-overlay-oe4t/recipes-core/base-files/base-files_%.bbappend
+++ b/layers/meta-trellis-swupdate-rootfs-overlay-oe4t/recipes-core/base-files/base-files_%.bbappend
@@ -9,9 +9,11 @@ SRC_URI:append = " \
 inherit systemd tegra_dataimg
 
 # Make sure the /data mountpoint is present
-# Add a /data/log symlink target
+# Add a /data/symlinks/var/log symlink target
 dirs755:append = " /data"
-dirs755:append = " /data/log"
+dirs755:append = " /data/symlinks"
+dirs755:append = " /data/symlinks/var"
+dirs755:append = " /data/symlinks/var/log"
 
 # Remove the symlink to volatile on log, we'll add our own /data partition symlink
 volatiles:remove = "log"
@@ -20,13 +22,13 @@ volatiles:remove = "log"
 do_install:append() {
     sed -e"s!@TEGRA_DATA_PART_LABEL@!${TEGRA_DATA_PART_LABEL}!g" -i ${S}/additions.fstab
     cat ${S}/additions.fstab >> ${D}${sysconfdir}/fstab
-    ln -s ../data/log ${D}${localstatedir}/log
+    ln -s ../data/symlinks/var/log ${D}${localstatedir}/log
     install -d 0755 ${D}${sysconfdir}/systemd/system/systemd-networkd-persistent-storage.service.d/
     install -m 0644 10-wait-for-var-volatile-lib.conf ${D}${sysconfdir}/systemd/system/systemd-networkd-persistent-storage.service.d/
     install -d 0755 ${D}${sysconfdir}/systemd/system/systemd-timesyncd.service.d/
     install -m 0644 10-wait-for-var-volatile-lib.conf ${D}${sysconfdir}/systemd/system/systemd-timesyncd.service.d/
     install -d 0755 ${D}${sysconfdir}/systemd/system/data-overlay-setup.service.d/
-    # Add the /data/log dir in case it's not there already (upgrade scenario)
+    # Add the /data/symlinks/var/log dir in case it's not there already (upgrade scenario)
     install -m 0644 10-add-data-log-dir.conf ${D}${sysconfdir}/systemd/system/data-overlay-setup.service.d/
 }
 

--- a/layers/meta-trellis-swupdate-rootfs-overlay-oe4t/recipes-test/test-rootfs-overlay/files/test-factory-reset.sh
+++ b/layers/meta-trellis-swupdate-rootfs-overlay-oe4t/recipes-test/test-rootfs-overlay/files/test-factory-reset.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+rm -rf /data/overlays/*
+rm -rf /data/symlinks/*
+echo "Removed persistent data, reboot for changes to take effect"

--- a/layers/meta-trellis-swupdate-rootfs-overlay-oe4t/recipes-test/test-rootfs-overlay/files/test-rootfs-overlay.sh
+++ b/layers/meta-trellis-swupdate-rootfs-overlay-oe4t/recipes-test/test-rootfs-overlay/files/test-rootfs-overlay.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+rtn=0
+failtext="ERROR: "
+failure() {
+    echo "${failtext} $1"
+    rtn=1
+}
+
+checklink() {
+    rootfsdir=$1
+    targetdir=/data/symlinks$rootfsdir
+    [ -h ${rootfsdir} ] || failure "${rootfsdir} not setup as symlink"
+    target=$(realpath $(dirname $rootfsdir)/$(readlink ${rootfsdir}))
+    [ "${target}" == "${targetdir}" ] || failure "${rootfsdir} pointing to ${target} instead of expected ${targetdir}"
+}
+
+cat /etc/mtab  | grep '^overlay /home' || failure "home overlay does not exist"
+cat /etc/mtab | awk '{ if ($2 == "/") { print } else { next } }' | grep "ro" || failure "rootfs is not read only"
+
+datapart_size_blocks=$(df  /data | awk '{ print $4 }' | tail -n 1)
+[ $datapart_size_blocks -gt 1000000 ] || failure "/data partition is ${datapart_size_blocks}, did growfs fail?"
+
+checklink /var/log
+checklink /etc/ssh/keys
+
+if [ $rtn -eq 0 ]; then
+    echo "All tests succeeded"
+else
+    echo "At least one test failed"
+fi 
+exit $rtn

--- a/layers/meta-trellis-swupdate-rootfs-overlay-oe4t/recipes-test/test-rootfs-overlay/test-rootfs-overlay_1.0.bb
+++ b/layers/meta-trellis-swupdate-rootfs-overlay-oe4t/recipes-test/test-rootfs-overlay/test-rootfs-overlay_1.0.bb
@@ -1,0 +1,22 @@
+DESCRIPTION = "Test scripts for data overlay and symlink layer"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
+
+SRC_URI = "\
+    file://test-rootfs-overlay.sh \
+    file://test-factory-reset.sh \
+"
+
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
+B = "${WORKDIR}/build"
+
+UNPACKDIR_COMPAT = "${@'${WORKDIR}' if not d.getVar('UNPACKDIR') else d.getVar('UNPACKDIR', expand=True)}"
+
+do_install:append() {
+    install -d 0744 ${D}${bindir}
+    install ${UNPACKDIR_COMPAT}/test-rootfs-overlay.sh -m 0755 ${D}${bindir}
+    install ${UNPACKDIR_COMPAT}/test-factory-reset.sh -m 0755 ${D}${bindir}
+}
+
+FILES:${PN} += "${bindir}/*"


### PR DESCRIPTION
* Support building the kirkstone branch of relevant repos from main branch of kas-demos
* Push required changes to the rootfs overlay layer to the kirkstone branch of kas-demos
* On kirkstone builds, replace the layer from this repo with a new clone of this repo and the underlying kirkstone branch layer
* Temporarily point to working branche from trellis-logic for tegra-demo-distro kirkstone swupdate support until backport is complete.