### PR TITLE
kas-build-oe4t: improve actions

### DIFF
--- a/.github/workflows/kas-build-oe4t.yml
+++ b/.github/workflows/kas-build-oe4t.yml
@@ -45,6 +45,7 @@ jobs:
           echo "Using ARTIFACT_RETENTION_DAYS=${ARTIFACT_RETENTION_DAYS}"
  
       - name: Build ${{ matrix.buildproj }} branch ${{ matrix.branch }}
+        continue-on-error: true
         run: |
           export builddir=${{ matrix.buildproj }}-${{ matrix.branch }}
           echo "builddir=${builddir}" >> "$GITHUB_ENV"

--- a/.github/workflows/kas-build-oe4t.yml
+++ b/.github/workflows/kas-build-oe4t.yml
@@ -13,6 +13,8 @@ env:
   ARTIFACT_RETENTION_DAYS_DEFAULT: 3
   MACHINE: jetson-orin-nano-devkit-nvme
   SWUPDATE_CORE_IMAGE_NAME: demo-image-base
+  SSTATE_DIR_BASE: /srv/yocto/sstate-cache
+  DL_DIR_DEFAULT: /srv/yocto/downloads
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -27,15 +29,19 @@ jobs:
 
       - name: Set env vars
         run: |
-          if [ -n "${SSTATE_DIR}" ]; then
-            export SSTATE_DIR=${SSTATE_DIR}/swupdate-oe4t-${{ matrix.branch }}
-            echo "SSTATE_DIR=${SSTATE_DIR}" >> "$GITHUB_ENV"
+          if [ -z "${DL_DIR}" ]; then
+            export DL_DIR=${DL_DIR_DEFAULT}
+          fi
+          if [ -z "${SSTATE_DIR}" ]; then
+            export SSTATE_DIR=${SSTATE_DIR_BASE}/swupdate-oe4t-${{ matrix.branch }}
+          fi
+          if [ -z "${ARTIFACT_RETENTION_DAYS}" ]; then
+            export ARTIFACT_RETENTION_DAYS=${ARTIFACT_RETENTION_DAYS_DEFAULT}
           fi
           echo "Running kas build with SSTATE_DIR=${SSTATE_DIR} DL_DIR=${DL_DIR}"
-          if [ -n "${ARTIFACT_RETENTION_DAYS}" ]; then
-            export ARTIFACT_RETENTION_DAYS=${ARTIFACT_RETENTION_DAYS_DEFAULT}
-            echo "ARTIFACT_RETENTION_DAYS=${ARTIFACT_RETENTION_DAYS}" >> "$GITHUB_ENV"
-          fi
+          echo "DL_DIR=${DL_DIR}" >> "$GITHUB_ENV"
+          echo "SSTATE_DIR=${SSTATE_DIR}" >> "$GITHUB_ENV"
+          echo "ARTIFACT_RETENTION_DAYS=${ARTIFACT_RETENTION_DAYS}" >> "$GITHUB_ENV"
           echo "Using ARTIFACT_RETENTION_DAYS=${ARTIFACT_RETENTION_DAYS}"
  
       - name: Build ${{ matrix.buildproj }} branch ${{ matrix.branch }}

--- a/.github/workflows/kas-build-oe4t.yml
+++ b/.github/workflows/kas-build-oe4t.yml
@@ -56,13 +56,110 @@ jobs:
           echo "running kas container build for ${{ matrix.buildproj }} on branch ${{ matrix.branch }}"
           kas-container build ../kas/${{ matrix.buildproj}}-${{ matrix.branch }}.yml
 
+      - name: Debug build directory tree for ${{ matrix.buildproj }} branch ${{ matrix.branch }}
+        if: always()
+        run: |
+          echo "builddir=${builddir:-<unset>}"
+          if [ -n "${builddir:-}" ] && [ -d "${builddir}" ]; then
+            if command -v tree >/dev/null 2>&1; then
+              tree -a -L 4 "${builddir}" || true
+            else
+              echo "tree not installed; using find"
+              find "${builddir}" -maxdepth 4 -print || true
+            fi
+          else
+            echo "Build directory not found: ${builddir:-<unset>}"
+          fi
+
+      - name: Stage artifacts for ${{ matrix.buildproj }} branch ${{ matrix.branch }}
+        run: |
+          set -euo pipefail
+
+          : "${builddir:?builddir env var not set (expected from previous step)}"
+
+          deploy_dir="${builddir}/build/tmp/deploy/images/${{ env.MACHINE }}"
+          staging_dir="${builddir}/artifact-staging"
+
+          mkdir -p "${staging_dir}"
+
+          image_prefix="${SWUPDATE_CORE_IMAGE_NAME}-${MACHINE}"
+
+          shopt -s nullglob
+
+          files=()
+
+          # Only one of these should exist depending on branch age:
+          # - newer branches: ${image_prefix}.rootfs.tegraflash.tar.*
+          # - older branches: ${image_prefix}.tegraflash.tar.*
+          tegra_rootfs_candidates=("${deploy_dir}/${image_prefix}.rootfs.tegraflash.tar."*)
+          tegra_plain_candidates=("${deploy_dir}/${image_prefix}.tegraflash.tar."*)
+
+          if [ ${#tegra_rootfs_candidates[@]} -gt 0 ]; then
+            if [ ${#tegra_plain_candidates[@]} -gt 0 ]; then
+              echo "Both rootfs and legacy tegraflash artifacts exist; preferring rootfs.*"
+            fi
+            tegra_candidates=("${tegra_rootfs_candidates[@]}")
+          else
+            tegra_candidates=("${tegra_plain_candidates[@]}")
+          fi
+
+          # Prefer symlinks (Yocto often creates stable-name symlinks -> timestamped real files).
+          tegra_symlinks=()
+          tegra_regulars=()
+          for f in "${tegra_candidates[@]}"; do
+            if [ -L "${f}" ]; then
+              tegra_symlinks+=("${f}")
+            else
+              tegra_regulars+=("${f}")
+            fi
+          done
+          if [ ${#tegra_symlinks[@]} -gt 0 ]; then
+            files+=("${tegra_symlinks[@]}")
+          else
+            files+=("${tegra_regulars[@]}")
+          fi
+
+          # For .swu, include the stable-name file if it exists (symlink or regular file).
+          swu_candidate="${deploy_dir}/${image_prefix}.swu"
+          if [ -e "${swu_candidate}" ] || [ -L "${swu_candidate}" ]; then
+            files+=("${swu_candidate}")
+          fi
+
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No tegraflash.tar.* or .swu files found for ${image_prefix} under: ${deploy_dir}"
+            echo "Directory tree (depth 6) for ${builddir}:"
+            if command -v tree >/dev/null 2>&1; then
+              tree -a -L 6 "${builddir}" || true
+            else
+              echo "tree not installed; using find"
+              find "${builddir}" -maxdepth 6 -print || true
+            fi
+            exit 1
+          fi
+
+          for f in "${files[@]}"; do
+            base="$(basename "${f}")"
+            dest="${staging_dir}/${base}"
+
+            if [ -e "${dest}" ]; then
+              echo "Duplicate artifact filename after flattening: ${base}"
+              echo "Source file: ${f}"
+              exit 1
+            fi
+
+            # -L/--dereference: if ${f} is a symlink, copy the linked-to file contents
+            # while keeping the symlink's filename in the staged artifact.
+            cp -vL "${f}" "${dest}"
+          done
+
+          echo "Staged artifacts:"
+          ls -la "${staging_dir}"
+
       - name: Upload artifacts for ${{ matrix.buildproj }} branch ${{ matrix.branch }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.buildproj }}-${{ matrix.branch }}-${{ env.SWUPDATE_CORE_IMAGE_NAME }}-${{ env.MACHINE }}
-          path: |
-           ${{ env.builddir }}/build/tmp/deploy/images/${{ env.MACHINE }}/${{ env.SWUPDATE_CORE_IMAGE_NAME}}-${{ env.MACHINE }}.tegraflash.tar.*
-           ${{ env.builddir }}/build/tmp/deploy/images/${{ env.MACHINE }}/${{ env.SWUPDATE_CORE_IMAGE_NAME}}-${{ env.MACHINE }}.rootfs.tegraflash.tar.*
-           ${{ env.builddir }}/build/tmp/deploy/images/${{ env.MACHINE }}/${{ env.SWUPDATE_CORE_IMAGE_NAME}}-${{ env.MACHINE }}.swu
-           retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+          path: ${{ env.builddir }}/artifact-staging/*
+          if-no-files-found: error
+          retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
 

--- a/.github/workflows/kas-build-oe4t.yml
+++ b/.github/workflows/kas-build-oe4t.yml
@@ -21,6 +21,7 @@ jobs:
   build:
     runs-on: self-hosted
     strategy:
+      fail-fast: false
       matrix:
         buildproj: [ swupdate-oe4t, swupdate-rootfs-overlay-oe4t ]
         branch: [ kirkstone, scarthgap-l4t-r35.x, scarthgap, master ]
@@ -78,15 +79,32 @@ jobs:
           : "${builddir:?builddir env var not set (expected from previous step)}"
 
           deploy_dir="${builddir}/build/tmp/deploy/images/${{ env.MACHINE }}"
-          staging_dir="${builddir}/artifact-staging"
+          staging_dir_tegra="${builddir}/artifact-staging-tegraflash"
+          staging_dir_swu="${builddir}/artifact-staging-swu"
 
-          mkdir -p "${staging_dir}"
+          mkdir -p "${staging_dir_tegra}" "${staging_dir_swu}"
 
           image_prefix="${SWUPDATE_CORE_IMAGE_NAME}-${MACHINE}"
 
           shopt -s nullglob
 
-          files=()
+          dump_deploy_dir() {
+            echo "Contents of deploy dir: ${deploy_dir}"
+            if [ -d "${deploy_dir}" ]; then
+              ls -la "${deploy_dir}" || true
+            else
+              echo "Deploy dir does not exist: ${deploy_dir}"
+              parent_dir="$(dirname "${deploy_dir}")"
+              if [ -d "${parent_dir}" ]; then
+                echo "Contents of parent dir: ${parent_dir}"
+                ls -la "${parent_dir}" || true
+              fi
+            fi
+          }
+
+          tegra_files=()
+          swu_files=()
+          missing=0
 
           # Only one of these should exist depending on branch age:
           # - newer branches: ${image_prefix}.rootfs.tegraflash.tar.*
@@ -103,30 +121,55 @@ jobs:
             tegra_candidates=("${tegra_plain_candidates[@]}")
           fi
 
-          # Prefer symlinks (Yocto often creates stable-name symlinks -> timestamped real files).
-          tegra_symlinks=()
-          tegra_regulars=()
-          for f in "${tegra_candidates[@]}"; do
-            if [ -L "${f}" ]; then
-              tegra_symlinks+=("${f}")
-            else
-              tegra_regulars+=("${f}")
-            fi
-          done
-          if [ ${#tegra_symlinks[@]} -gt 0 ]; then
-            files+=("${tegra_symlinks[@]}")
+          if [ ${#tegra_candidates[@]} -eq 0 ]; then
+            echo "ERROR: No tegraflash.tar.* found for ${image_prefix} under: ${deploy_dir}"
+            dump_deploy_dir
+            missing=1
           else
-            files+=("${tegra_regulars[@]}")
+            # Prefer symlinks (Yocto often creates stable-name symlinks -> timestamped real files).
+            tegra_symlinks=()
+            tegra_regulars=()
+            for f in "${tegra_candidates[@]}"; do
+              if [ -L "${f}" ]; then
+                tegra_symlinks+=("${f}")
+              else
+                tegra_regulars+=("${f}")
+              fi
+            done
+            if [ ${#tegra_symlinks[@]} -gt 0 ]; then
+              tegra_files+=("${tegra_symlinks[@]}")
+            else
+              tegra_files+=("${tegra_regulars[@]}")
+            fi
           fi
 
-          # For .swu, include the stable-name file if it exists (symlink or regular file).
-          swu_candidate="${deploy_dir}/${image_prefix}.swu"
-          if [ -e "${swu_candidate}" ] || [ -L "${swu_candidate}" ]; then
-            files+=("${swu_candidate}")
+          # SWU filename does not necessarily share the same prefix as the core image
+          # (e.g. swupdate-image-*.swu vs demo-image-base-*). Find any .swu in deploy_dir.
+          swu_candidates=("${deploy_dir}"/*.swu)
+
+          if [ ${#swu_candidates[@]} -eq 0 ]; then
+            echo "ERROR: No .swu found under: ${deploy_dir}"
+            dump_deploy_dir
+            missing=1
+          else
+            swu_symlinks=()
+            swu_regulars=()
+            for f in "${swu_candidates[@]}"; do
+              if [ -L "${f}" ]; then
+                swu_symlinks+=("${f}")
+              else
+                swu_regulars+=("${f}")
+              fi
+            done
+
+            if [ ${#swu_symlinks[@]} -gt 0 ]; then
+              swu_files+=("${swu_symlinks[@]}")
+            else
+              swu_files+=("${swu_regulars[@]}")
+            fi
           fi
 
-          if [ ${#files[@]} -eq 0 ]; then
-            echo "No tegraflash.tar.* or .swu files found for ${image_prefix} under: ${deploy_dir}"
+          if [ ${missing} -ne 0 ]; then
             echo "Directory tree (depth 6) for ${builddir}:"
             if command -v tree >/dev/null 2>&1; then
               tree -a -L 6 "${builddir}" || true
@@ -137,29 +180,47 @@ jobs:
             exit 1
           fi
 
-          for f in "${files[@]}"; do
-            base="$(basename "${f}")"
-            dest="${staging_dir}/${base}"
+          stage_files() {
+            local dest_dir="$1"; shift
+            local label="$1"; shift
+            local -a src_files=("$@")
 
-            if [ -e "${dest}" ]; then
-              echo "Duplicate artifact filename after flattening: ${base}"
-              echo "Source file: ${f}"
-              exit 1
-            fi
+            echo "Staging ${label} to ${dest_dir}"
+            for f in "${src_files[@]}"; do
+              base="$(basename "${f}")"
+              dest="${dest_dir}/${base}"
 
-            # -L/--dereference: if ${f} is a symlink, copy the linked-to file contents
-            # while keeping the symlink's filename in the staged artifact.
-            cp -vL "${f}" "${dest}"
-          done
+              if [ -e "${dest}" ]; then
+                echo "Duplicate artifact filename after flattening (${label}): ${base}"
+                echo "Source file: ${f}"
+                exit 1
+              fi
 
-          echo "Staged artifacts:"
-          ls -la "${staging_dir}"
+              # -L/--dereference: if ${f} is a symlink, copy the linked-to file contents
+              # while keeping the symlink's filename in the staged artifact.
+              cp -vL "${f}" "${dest}"
+            done
 
-      - name: Upload artifacts for ${{ matrix.buildproj }} branch ${{ matrix.branch }}
+            echo "Staged ${label}:"
+            ls -la "${dest_dir}"
+          }
+
+          stage_files "${staging_dir_tegra}" tegraflash "${tegra_files[@]}"
+          stage_files "${staging_dir_swu}" swu "${swu_files[@]}"
+
+      - name: Upload tegraflash artifacts for ${{ matrix.buildproj }} branch ${{ matrix.branch }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.buildproj }}-${{ matrix.branch }}-${{ env.SWUPDATE_CORE_IMAGE_NAME }}-${{ env.MACHINE }}
-          path: ${{ env.builddir }}/artifact-staging/*
+          name: ${{ matrix.buildproj }}-${{ matrix.branch }}-${{ env.SWUPDATE_CORE_IMAGE_NAME }}-${{ env.MACHINE }}-tegraflash
+          path: ${{ env.builddir }}/artifact-staging-tegraflash/*
+          if-no-files-found: error
+          retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+
+      - name: Upload swu artifacts for ${{ matrix.buildproj }} branch ${{ matrix.branch }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.buildproj }}-${{ matrix.branch }}-${{ env.SWUPDATE_CORE_IMAGE_NAME }}-${{ env.MACHINE }}-swu
+          path: ${{ env.builddir }}/artifact-staging-swu/*
           if-no-files-found: error
           retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
 

--- a/.github/workflows/kas-build-oe4t.yml
+++ b/.github/workflows/kas-build-oe4t.yml
@@ -162,11 +162,15 @@ jobs:
               fi
             done
 
+            # Only one SWU is needed. Prefer a stable-name symlink if present.
             if [ ${#swu_symlinks[@]} -gt 0 ]; then
-              swu_files+=("${swu_symlinks[@]}")
+              swu_pick="${swu_symlinks[0]}"
             else
-              swu_files+=("${swu_regulars[@]}")
+              swu_pick="${swu_regulars[0]}"
             fi
+
+            echo "Selected SWU: ${swu_pick}"
+            swu_files+=("${swu_pick}")
           fi
 
           if [ ${missing} -ne 0 ]; then


### PR DESCRIPTION
Improve github actions and artifact updates for kas-build-oe4t.

* Require both swu and tegraflash files to be found as artifacts of build
* Upload artifacts independently to speed up download times in cases where you only need one of the two.
* Add debug logging when files aren't found after build so actions logs can help determine the issue.
* Continue on error so future builds are still attempted when one build fails.